### PR TITLE
Fix crip download url

### DIFF
--- a/automatic/crip/crip.nuspec
+++ b/automatic/crip/crip.nuspec
@@ -46,7 +46,7 @@ Commands:
   export pem        Export the extracted certificate to a base64 encoded string also known as PEM
 ```
 </description>
-    <releaseNotes>https://github.com/Hakky54/certificate-ripper/releases/tag/v2.6.0</releaseNotes>
+    <releaseNotes>https://github.com/Hakky54/certificate-ripper/releases/tag/2.6.0</releaseNotes>
     <dependencies>
       <dependency id="vcredist140" />
     </dependencies>

--- a/automatic/crip/tools/chocolateyinstall.ps1
+++ b/automatic/crip/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   unzipLocation  = $packagePath
   softwareName   = 'crip*'
-  url64bit       = 'https://github.com/Hakky54/certificate-ripper/releases/download/v2.6.0/crip-windows-amd64.zip'
+  url64bit       = 'https://github.com/Hakky54/certificate-ripper/releases/download/2.6.0/crip-windows-amd64.zip'
   checksum64     = '479c33a877049d66f19febd606793e8c8635d3079ca3f4a9562f56b7efc1f742'
   checksumType64 = 'sha256'
 }


### PR DESCRIPTION
The `v` got dropped from the tags, it seems.